### PR TITLE
feat: add WebP support to image pipelines

### DIFF
--- a/components/app.tsx
+++ b/components/app.tsx
@@ -197,7 +197,7 @@ export default function App(): ReactElement {
       }
       if (rejected.length) {
         toaster.create({
-          title: "Dropped file was not an SVG, PNG, or JPEG",
+          title: "Dropped file was not an SVG, PNG, JPEG, or WebP",
           type: "error",
         });
       }
@@ -210,6 +210,7 @@ export default function App(): ReactElement {
       "image/svg+xml": [],
       "image/png": [],
       "image/jpeg": [],
+      "image/webp": [],
     },
     multiple: false,
     noClick: true,

--- a/components/upload-button.tsx
+++ b/components/upload-button.tsx
@@ -24,7 +24,7 @@ export default function UploadButton({
       <input
         ref={input}
         type="file"
-        accept="image/svg+xml, image/png, image/jpeg"
+        accept="image/svg+xml, image/png, image/jpeg, image/webp"
         onChange={onChange}
         className="hidden"
       />

--- a/utils/conversion.ts
+++ b/utils/conversion.ts
@@ -35,5 +35,5 @@ export async function resizeBlob(
   const canvas = new OffscreenCanvas(width, height);
   const ctx = canvas.getContext("2d")!;
   ctx.drawImage(bmp, 0, 0, width, height);
-  return await canvas.convertToBlob();
+  return await canvas.convertToBlob({ type: inp.type });
 }

--- a/utils/separate.ts
+++ b/utils/separate.ts
@@ -8,7 +8,11 @@ const COLOR_PROPS = ["fill", "stroke", "stopColor"] as const;
 async function* extractColors(
   blob: Blob,
 ): AsyncIterableIterator<ColorSpaceObject> {
-  if (blob.type === "image/png" || blob.type === "image/jpeg") {
+  if (
+    blob.type === "image/png" ||
+    blob.type === "image/jpeg" ||
+    blob.type === "image/webp"
+  ) {
     const bmp = await createImageBitmap(blob);
     const canvas = new OffscreenCanvas(bmp.width, bmp.height);
     const ctx = canvas.getContext("2d")!;
@@ -59,7 +63,11 @@ async function updateColors(
   blob: Blob,
   update: (css: ColorSpaceObject) => ColorSpaceObject,
 ): Promise<Blob> {
-  if (blob.type === "image/png" || blob.type === "image/jpeg") {
+  if (
+    blob.type === "image/png" ||
+    blob.type === "image/jpeg" ||
+    blob.type === "image/webp"
+  ) {
     const bmp = await createImageBitmap(blob);
     const canvas = new OffscreenCanvas(bmp.width, bmp.height);
     const ctx = canvas.getContext("2d")!;
@@ -73,7 +81,7 @@ async function updateColors(
       imdat.data.set([r, g, b], i);
     }
     ctx.putImageData(imdat, 0, 0);
-    return await canvas.convertToBlob();
+    return await canvas.convertToBlob({ type: blob.type });
   } else if (blob.type === "image/svg+xml") {
     const text = await blob.text();
     const parser = new DOMParser();


### PR DESCRIPTION

Accept image/webp uploads alongside SVG/PNG/JPEG and roundtrip the
original raster format through convertToBlob instead of defaulting
to PNG.
