### PR TITLE
feat: add hold-to-view channel grid button

### DIFF
--- a/components/app.tsx
+++ b/components/app.tsx
@@ -15,7 +15,11 @@ import {
 } from "react";
 import { type FileRejection, useDropzone } from "react-dropzone";
 import { blob2url, resizeBlob, url2blob } from "../utils/conversion";
-import { genPreview, genSeparation } from "../utils/separate";
+import {
+  genGrid,
+  genPreviewAndSeparation,
+  genSeparation,
+} from "../utils/separate";
 import DropModal from "./drop-modal";
 import Editor, { type Action } from "./editor";
 import Footer from "./footer";
@@ -33,6 +37,7 @@ interface Parsed {
 
 export default function App(): ReactElement {
   const [showRaw, setShowRaw] = useState(false);
+  const [showGrid, setShowGrid] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
   const [rendering, setRendering] = useState(false);
   const [isDownloading, setDownloading] = useState(false);
@@ -70,38 +75,63 @@ export default function App(): ReactElement {
   );
 
   const [preview, setPreview] = useState<string | undefined>();
+  const [grid, setGrid] = useState<string | undefined>();
   const [increments, setIncrements] = useState(0);
 
   useEffect(() => {
-    if (!parsed || ![...colors.values()].some(([, active]) => active)) {
+    if (!parsed) {
       setPreview(undefined);
-    } else {
-      void (async () => {
-        try {
-          setRendering(true);
-
-          const pool = [];
-          for (const [color, [, active]] of colors) {
-            if (active) {
-              pool.push(d3color.color(color)!);
-            }
-          }
-          const blob = await url2blob(parsed.preview);
-          const updated = await genPreview(blob, pool, increments);
-          const url = await blob2url(updated);
-          setPreview(url);
-        } catch (ex) {
-          console.error(ex);
+      setGrid(undefined);
+      return;
+    }
+    const pool = [];
+    const names = [];
+    for (const [color, [name, active]] of colors) {
+      if (active) {
+        pool.push(d3color.color(color)!);
+        names.push(name);
+      }
+    }
+    if (!pool.length) {
+      setPreview(undefined);
+      setGrid(undefined);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        setRendering(true);
+        const blob = await url2blob(parsed.preview);
+        const { preview: previewBlob, separations } =
+          await genPreviewAndSeparation(blob, pool, increments);
+        const gridBlob = await genGrid(separations, names, pool);
+        const [previewUrl, gridUrl] = await Promise.all([
+          blob2url(previewBlob),
+          blob2url(gridBlob),
+        ]);
+        if (!cancelled) {
+          setPreview(previewUrl);
+          setGrid(gridUrl);
+        }
+      } catch (ex) {
+        console.error(ex);
+        if (!cancelled) {
           setPreview(undefined);
+          setGrid(undefined);
           toaster.create({
             title: "Couldn't separate image",
             type: "error",
           });
-        } finally {
+        }
+      } finally {
+        if (!cancelled) {
           setRendering(false);
         }
-      })();
-    }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, [colors, increments, parsed]);
 
   const download = useCallback(() => {
@@ -173,12 +203,17 @@ export default function App(): ReactElement {
         download={download}
         isDownloading={isDownloading}
         setShowRaw={setShowRaw}
+        setShowGrid={setShowGrid}
         rendering={rendering}
       />
     ) : (
       <HelpText closeable={!!parsed} />
     );
-  const src = showRaw ? parsed?.preview : (preview ?? parsed?.preview);
+  const src = showRaw
+    ? parsed?.preview
+    : showGrid && grid
+      ? grid
+      : (preview ?? parsed?.preview);
   const img = src ? (
     <Image
       src={src}

--- a/components/editor.tsx
+++ b/components/editor.tsx
@@ -23,6 +23,7 @@ export default function Editor({
   download,
   isDownloading,
   setShowRaw,
+  setShowGrid,
   rendering,
 }: {
   colors: Map<string, [string, boolean]>;
@@ -32,6 +33,7 @@ export default function Editor({
   download: () => void;
   isDownloading: boolean;
   setShowRaw: (val: boolean) => void;
+  setShowGrid: (val: boolean) => void;
   rendering: boolean;
 }): ReactElement {
   const exportText = colors.size
@@ -43,6 +45,12 @@ export default function Editor({
   const onUp = useCallback(() => {
     setShowRaw(false);
   }, [setShowRaw]);
+  const onGridDown = useCallback(() => {
+    setShowGrid(true);
+  }, [setShowGrid]);
+  const onGridUp = useCallback(() => {
+    setShowGrid(false);
+  }, [setShowGrid]);
   const toggleColor = useCallback(
     (color: string) => {
       modifyColors({ action: "toggle", color });
@@ -72,6 +80,15 @@ export default function Editor({
         type="button"
       >
         Toggle Original
+      </button>
+      <button
+        className="w-full px-4 py-2 bg-slate-300 hover:bg-slate-400 text-slate-800 dark:bg-slate-600 dark:hover:bg-slate-500 dark:text-white rounded disabled:opacity-50 disabled:pointer-events-none"
+        disabled={!selected}
+        onMouseDown={onGridDown}
+        onMouseUp={onGridUp}
+        type="button"
+      >
+        Toggle Channels
       </button>
       <Tooltip.Root>
         <Tooltip.Trigger asChild>

--- a/utils/bulksep.ts
+++ b/utils/bulksep.ts
@@ -1,20 +1,20 @@
 import type { ColorSpaceObject } from "d3-color";
-import * as d3color from "d3-color";
+import { packRgb, type RgbU32 } from "./color";
 import type { Result } from "./winterface";
 
 export async function* bulkColorSeparation(
-  colorIter: AsyncIterable<ColorSpaceObject>,
+  colorIter: AsyncIterable<RgbU32>,
   pool: readonly ColorSpaceObject[],
   increments: number,
-): AsyncIterableIterator<[string, ColorSpaceObject, number[]]> {
-  const colors = new Set<string>();
+): AsyncIterableIterator<[RgbU32, RgbU32, number[]]> {
+  const colors = new Set<RgbU32>();
   for await (const color of colorIter) {
-    colors.add(color.formatHex());
+    colors.add(color);
   }
-  const transPool = new Uint8ClampedArray(pool.length * 3);
+  const transPool = new Uint32Array(pool.length);
   for (const [i, color] of pool.entries()) {
     const { r, g, b } = color.rgb();
-    transPool.set([r, g, b], i * 3);
+    transPool[i] = packRgb(r, g, b);
   }
 
   const message = { colors, pool: transPool, increments };
@@ -34,9 +34,8 @@ export async function* bulkColorSeparation(
   const { prevs, opacs } = res;
   let i = 0;
   for (const key of colors) {
-    const [r, g, b] = prevs.slice(i * 3, (i + 1) * 3);
     const opac = [...opacs.slice(i * pool.length, (i + 1) * pool.length)];
-    yield [key, d3color.rgb(r, g, b), opac];
+    yield [key, prevs[i], opac];
     i++;
   }
 }

--- a/utils/color.ts
+++ b/utils/color.ts
@@ -1,0 +1,14 @@
+/** RGB color packed into a single 32-bit integer: (r << 16) | (g << 8) | b. */
+export type RgbU32 = number;
+
+export function packRgb(r: number, g: number, b: number): RgbU32 {
+  return (
+    ((Math.round(r) & 0xff) << 16) |
+    ((Math.round(g) & 0xff) << 8) |
+    (Math.round(b) & 0xff)
+  );
+}
+
+export function unpackRgb(c: RgbU32): { r: number; g: number; b: number } {
+  return { r: (c >> 16) & 0xff, g: (c >> 8) & 0xff, b: c & 0xff };
+}

--- a/utils/raster-worker.ts
+++ b/utils/raster-worker.ts
@@ -1,0 +1,103 @@
+import * as d3color from "d3-color";
+import { packRgb, type RgbU32, unpackRgb } from "./color";
+import { colorSeparation } from "./sep";
+import type { RasterMessage, RasterResult } from "./winterface";
+
+addEventListener("message", (event: MessageEvent<RasterMessage>) => {
+  void run(event.data);
+});
+
+async function run(message: RasterMessage): Promise<void> {
+  try {
+    const { blob, pool, increments, outputType } = message;
+    const numChannels = pool.length;
+    const numOutputs = 1 + numChannels;
+
+    const bmp = await createImageBitmap(blob);
+    const { width, height } = bmp;
+    const srcCanvas = new OffscreenCanvas(width, height);
+    const srcCtx = srcCanvas.getContext("2d")!;
+    srcCtx.drawImage(bmp, 0, 0);
+    const srcData = srcCtx.getImageData(0, 0, width, height, {
+      colorSpace: "srgb",
+    }).data;
+
+    const unique = new Set<RgbU32>();
+    for (let i = 0; i < srcData.length; i += 4) {
+      unique.add(packRgb(srcData[i], srcData[i + 1], srcData[i + 2]));
+    }
+
+    const colorPool: d3color.RGBColor[] = [];
+    for (let i = 0; i < pool.length; i++) {
+      const { r, g, b } = unpackRgb(pool[i]);
+      colorPool.push(d3color.rgb(r, g, b));
+    }
+
+    const triples = numOutputs * 3;
+    const lookup = new Map<RgbU32, Uint8Array>();
+    for (const key of unique) {
+      const { r, g, b } = unpackRgb(key);
+      const { color, opacities } = colorSeparation(
+        d3color.rgb(r, g, b),
+        colorPool,
+        { increments },
+      );
+      const { r: pr, g: pg, b: pb } = color.rgb();
+      const bytes = new Uint8Array(triples);
+      bytes[0] = pr;
+      bytes[1] = pg;
+      bytes[2] = pb;
+      for (let j = 0; j < numChannels; j++) {
+        const v = Math.round((1 - opacities[j]) * 255);
+        const base = 3 + j * 3;
+        bytes[base] = v;
+        bytes[base + 1] = v;
+        bytes[base + 2] = v;
+      }
+      lookup.set(key, bytes);
+    }
+
+    const outCanvases: OffscreenCanvas[] = [];
+    const outCtxs: OffscreenCanvasRenderingContext2D[] = [];
+    const outDatas: ImageData[] = [];
+    for (let j = 0; j < numOutputs; j++) {
+      const canvas = new OffscreenCanvas(width, height);
+      const ctx = canvas.getContext("2d")!;
+      outCanvases.push(canvas);
+      outCtxs.push(ctx);
+      outDatas.push(ctx.createImageData(width, height, { colorSpace: "srgb" }));
+    }
+
+    for (let i = 0; i < srcData.length; i += 4) {
+      const key = packRgb(srcData[i], srcData[i + 1], srcData[i + 2]);
+      const alpha = srcData[i + 3];
+      const bytes = lookup.get(key)!;
+      for (let j = 0; j < numOutputs; j++) {
+        const out = outDatas[j].data;
+        const base = j * 3;
+        out[i] = bytes[base];
+        out[i + 1] = bytes[base + 1];
+        out[i + 2] = bytes[base + 2];
+        out[i + 3] = alpha;
+      }
+    }
+
+    for (let j = 0; j < numOutputs; j++) {
+      outCtxs[j].putImageData(outDatas[j], 0, 0);
+    }
+    const blobs = await Promise.all(
+      outCanvases.map((canvas) => canvas.convertToBlob({ type: outputType })),
+    );
+
+    const result: RasterResult = {
+      typ: "success",
+      preview: blobs[0],
+      separations: blobs.slice(1),
+    };
+    postMessage(result);
+  } catch (ex) {
+    const err = ex instanceof Error ? ex.toString() : "unknown error";
+    const result: RasterResult = { typ: "err", err };
+    postMessage(result);
+  }
+}

--- a/utils/separate.ts
+++ b/utils/separate.ts
@@ -1,18 +1,50 @@
 import type { ColorSpaceObject } from "d3-color";
 import * as d3color from "d3-color";
 import { bulkColorSeparation } from "./bulksep";
+import { packRgb, type RgbU32, unpackRgb } from "./color";
 import { blob2url, url2blob } from "./conversion";
+import type { RasterMessage, RasterResult } from "./winterface";
 
 const COLOR_PROPS = ["fill", "stroke", "stopColor"] as const;
 
-async function* extractColors(
+function isRaster(type: string): boolean {
+  return type === "image/png" || type === "image/jpeg" || type === "image/webp";
+}
+
+async function rasterPipeline(
   blob: Blob,
-): AsyncIterableIterator<ColorSpaceObject> {
-  if (
-    blob.type === "image/png" ||
-    blob.type === "image/jpeg" ||
-    blob.type === "image/webp"
-  ) {
+  pool: readonly ColorSpaceObject[],
+  increments: number,
+): Promise<{ preview: Blob; separations: readonly Blob[] }> {
+  const transPool = new Uint32Array(pool.length);
+  for (const [i, color] of pool.entries()) {
+    const { r, g, b } = color.rgb();
+    transPool[i] = packRgb(r, g, b);
+  }
+  const message: RasterMessage = {
+    blob,
+    pool: transPool,
+    increments,
+    outputType: blob.type,
+  };
+  const worker = new Worker(new URL("./raster-worker.ts", import.meta.url));
+  const result = await new Promise<RasterResult>((resolve) => {
+    worker.addEventListener("message", (event: MessageEvent<RasterResult>) => {
+      resolve(event.data);
+      worker.terminate();
+    });
+    worker.postMessage(message, {
+      transfer: [transPool.buffer as ArrayBuffer],
+    });
+  });
+  if (result.typ === "err") {
+    throw new Error(result.err);
+  }
+  return { preview: result.preview, separations: result.separations };
+}
+
+async function* extractColors(blob: Blob): AsyncIterableIterator<RgbU32> {
+  if (isRaster(blob.type)) {
     const bmp = await createImageBitmap(blob);
     const canvas = new OffscreenCanvas(bmp.width, bmp.height);
     const ctx = canvas.getContext("2d")!;
@@ -21,13 +53,12 @@ async function* extractColors(
       colorSpace: "srgb",
     });
     for (let i = 0; i < data.length; i += 4) {
-      const [r, g, b] = data.slice(i, i + 3);
-      yield d3color.rgb(r, g, b);
+      yield packRgb(data[i], data[i + 1], data[i + 2]);
     }
   } else if (blob.type === "image/svg+xml") {
     const text = await blob.text();
     const parser = new DOMParser();
-    const svg = parser.parseFromString(text, blob.type);
+    const svg = parser.parseFromString(text, "image/svg+xml");
     for (const elem of svg.querySelectorAll("*")) {
       if (elem instanceof SVGStyleElement) {
         for (const rule of elem.sheet?.cssRules ?? []) {
@@ -35,7 +66,8 @@ async function* extractColors(
             for (const prop of COLOR_PROPS) {
               const color = d3color.color(rule.style?.[prop]);
               if (color) {
-                yield color;
+                const { r, g, b } = color.rgb();
+                yield packRgb(r, g, b);
               }
             }
           }
@@ -49,7 +81,8 @@ async function* extractColors(
         for (const prop of COLOR_PROPS) {
           const color = d3color.color(elem.style?.[prop]);
           if (color) {
-            yield color;
+            const { r, g, b } = color.rgb();
+            yield packRgb(r, g, b);
           }
         }
       }
@@ -61,73 +94,121 @@ async function* extractColors(
 
 async function updateColors(
   blob: Blob,
-  update: (css: ColorSpaceObject) => ColorSpaceObject,
-): Promise<Blob> {
+  updaters: readonly ((css: ColorSpaceObject) => ColorSpaceObject)[],
+): Promise<readonly Blob[]> {
   if (
     blob.type === "image/png" ||
     blob.type === "image/jpeg" ||
     blob.type === "image/webp"
   ) {
     const bmp = await createImageBitmap(blob);
-    const canvas = new OffscreenCanvas(bmp.width, bmp.height);
-    const ctx = canvas.getContext("2d")!;
-    ctx.drawImage(bmp, 0, 0);
-    const imdat = ctx.getImageData(0, 0, bmp.width, bmp.height, {
+    const { width, height } = bmp;
+    const srcCanvas = new OffscreenCanvas(width, height);
+    const srcCtx = srcCanvas.getContext("2d")!;
+    srcCtx.drawImage(bmp, 0, 0);
+    const srcData = srcCtx.getImageData(0, 0, width, height, {
       colorSpace: "srgb",
-    });
-    for (let i = 0; i < imdat.data.length; i += 4) {
-      const [ri, gi, bi] = imdat.data.slice(i, i + 3);
-      const { r, g, b } = update(d3color.rgb(ri, gi, bi)).rgb();
-      imdat.data.set([r, g, b], i);
+    }).data;
+    const outCanvases = updaters.map(() => new OffscreenCanvas(width, height));
+    const outCtxs = outCanvases.map((canvas) => canvas.getContext("2d")!);
+    const outDatas = outCtxs.map((ctx) =>
+      ctx.createImageData(width, height, { colorSpace: "srgb" }),
+    );
+    for (let i = 0; i < srcData.length; i += 4) {
+      const src = d3color.rgb(srcData[i], srcData[i + 1], srcData[i + 2]);
+      const alpha = srcData[i + 3];
+      for (let j = 0; j < updaters.length; j++) {
+        const { r, g, b } = updaters[j](src).rgb();
+        const out = outDatas[j].data;
+        out[i] = r;
+        out[i + 1] = g;
+        out[i + 2] = b;
+        out[i + 3] = alpha;
+      }
     }
-    ctx.putImageData(imdat, 0, 0);
-    return await canvas.convertToBlob({ type: blob.type });
+    for (let j = 0; j < outCtxs.length; j++) {
+      outCtxs[j].putImageData(outDatas[j], 0, 0);
+    }
+    return await Promise.all(
+      outCanvases.map((canvas) => canvas.convertToBlob({ type: blob.type })),
+    );
   } else if (blob.type === "image/svg+xml") {
     const text = await blob.text();
     const parser = new DOMParser();
-    const svg = parser.parseFromString(text, blob.type);
-
-    const proms = [];
-    for (const elem of svg.querySelectorAll("*")) {
-      if (elem instanceof SVGStyleElement) {
-        const rules = [...(elem.sheet?.cssRules ?? [])];
-        for (const rule of rules) {
-          if (rule instanceof CSSStyleRule) {
+    // Pre-process embedded images once across all updaters
+    const discovery = parser.parseFromString(text, "image/svg+xml");
+    const imageElements = [
+      ...discovery.querySelectorAll("image"),
+    ] as SVGImageElement[];
+    const processedImages = await Promise.all(
+      imageElements.map(async (elem) => {
+        const href = await url2blob(elem.href.baseVal);
+        const blobs = await updateColors(href, updaters);
+        return await Promise.all(blobs.map(blob2url));
+      }),
+    );
+    const serial = new XMLSerializer();
+    return await Promise.all(
+      updaters.map(async (update, updaterIdx) => {
+        const svg = parser.parseFromString(text, "image/svg+xml");
+        let imgIdx = 0;
+        for (const elem of svg.querySelectorAll("*")) {
+          if (elem instanceof SVGStyleElement) {
+            const rules = [...(elem.sheet?.cssRules ?? [])];
+            for (const rule of rules) {
+              if (rule instanceof CSSStyleRule) {
+                for (const prop of COLOR_PROPS) {
+                  const init = d3color.color(rule.style?.[prop]);
+                  if (init) {
+                    rule.style[prop] = update(init).toString();
+                  }
+                }
+              }
+            }
+            elem.textContent = rules.map((rule) => rule.cssText).join("\n");
+          } else if (elem instanceof SVGImageElement) {
+            elem.setAttribute("href", processedImages[imgIdx][updaterIdx]);
+            imgIdx++;
+          } else if (elem instanceof SVGElement) {
             for (const prop of COLOR_PROPS) {
-              const init = d3color.color(rule.style?.[prop]);
+              const init = d3color.color(elem.style[prop]);
               if (init) {
-                rule.style[prop] = update(init).toString();
+                elem.style[prop] = update(init).toString();
               }
             }
           }
         }
-        // need to actually update the style
-        elem.textContent = rules.map((rule) => rule.cssText).join("\n");
-      } else if (elem instanceof SVGImageElement) {
-        proms.push(
-          (async () => {
-            const href = await url2blob(elem.href.baseVal);
-            const blob = await updateColors(href, update);
-            const url = await blob2url(blob);
-            elem.setAttribute("href", url);
-          })(),
-        );
-      } else if (elem instanceof SVGElement) {
-        for (const prop of COLOR_PROPS) {
-          const init = d3color.color(elem.style[prop]);
-          if (init) {
-            elem.style[prop] = update(init).toString();
-          }
-        }
-      }
-    }
-    await Promise.all(proms);
-    const serial = new XMLSerializer();
-    const rendered = serial.serializeToString(svg);
-    return new Blob([rendered], { type: "image/svg+xml" });
+        return new Blob([serial.serializeToString(svg)], {
+          type: "image/svg+xml",
+        });
+      }),
+    );
   } else {
     throw new Error(`unhandled url type: ${blob.type}`);
   }
+}
+
+function previewUpdater(
+  update: ReadonlyMap<RgbU32, RgbU32>,
+): (orig: ColorSpaceObject) => ColorSpaceObject {
+  return (orig) => {
+    const { r: sr, g: sg, b: sb } = orig.rgb();
+    const { r, g, b } = unpackRgb(update.get(packRgb(sr, sg, sb))!);
+    return d3color.rgb(r, g, b, orig.opacity);
+  };
+}
+
+function separationUpdaters(
+  mapping: ReadonlyMap<RgbU32, number[]>,
+  poolSize: number,
+): readonly ((orig: ColorSpaceObject) => ColorSpaceObject)[] {
+  return Array.from({ length: poolSize }, (_, ind) => {
+    return (orig: ColorSpaceObject) => {
+      const { r: sr, g: sg, b: sb } = orig.rgb();
+      const opacity = mapping.get(packRgb(sr, sg, sb))![ind];
+      return d3color.gray((1 - opacity) * 100).copy({ opacity: orig.opacity });
+    };
+  });
 }
 
 export async function genPreview(
@@ -135,11 +216,11 @@ export async function genPreview(
   pool: readonly ColorSpaceObject[],
   increments: number,
 ): Promise<Blob> {
-  /* TODO some part of this initial setup still takes some time. I'm not sure
-   * if it's the image munging, or the color set creation. Theoretically, we
-   * could create the color set on the webworker, but in practice this turned
-   * out not as fast, and it's not clear why. */
-  const update = new Map<string, ColorSpaceObject>();
+  if (isRaster(blob.type)) {
+    const { preview } = await rasterPipeline(blob, pool, increments);
+    return preview;
+  }
+  const update = new Map<RgbU32, RgbU32>();
   for await (const [key, color] of bulkColorSeparation(
     extractColors(blob),
     pool,
@@ -147,12 +228,88 @@ export async function genPreview(
   )) {
     update.set(key, color);
   }
+  const [out] = await updateColors(blob, [previewUpdater(update)]);
+  return out;
+}
 
-  const updater = (orig: ColorSpaceObject): ColorSpaceObject => {
-    return update.get(orig.formatHex())!.copy({ opacity: orig.opacity });
-  };
+export async function genPreviewAndSeparation(
+  blob: Blob,
+  pool: readonly ColorSpaceObject[],
+  increments: number,
+): Promise<{ preview: Blob; separations: readonly Blob[] }> {
+  if (isRaster(blob.type)) {
+    return await rasterPipeline(blob, pool, increments);
+  }
+  const update = new Map<RgbU32, RgbU32>();
+  const mapping = new Map<RgbU32, number[]>();
+  for await (const [key, color, opac] of bulkColorSeparation(
+    extractColors(blob),
+    pool,
+    increments,
+  )) {
+    update.set(key, color);
+    mapping.set(key, opac);
+  }
+  const updaters = [
+    previewUpdater(update),
+    ...separationUpdaters(mapping, pool.length),
+  ];
+  const [preview, ...separations] = await updateColors(blob, updaters);
+  return { preview, separations };
+}
 
-  return await updateColors(blob, updater);
+export async function genGrid(
+  separations: readonly Blob[],
+  names: readonly string[],
+  colors: readonly ColorSpaceObject[],
+): Promise<Blob> {
+  const urls = separations.map((sep) => URL.createObjectURL(sep));
+  try {
+    const images = await Promise.all(
+      urls.map(
+        (url) =>
+          new Promise<HTMLImageElement>((resolve, reject) => {
+            const img = new Image();
+            img.onload = () => resolve(img);
+            img.onerror = () => reject(new Error(`failed to load ${url}`));
+            img.src = url;
+          }),
+      ),
+    );
+    const cellWidth = Math.max(...images.map((img) => img.naturalWidth));
+    const cellHeight = Math.max(...images.map((img) => img.naturalHeight));
+    const cols = Math.ceil(Math.sqrt(images.length));
+    const rows = Math.ceil(images.length / cols);
+    const canvas = new OffscreenCanvas(cols * cellWidth, rows * cellHeight);
+    const ctx = canvas.getContext("2d")!;
+    ctx.fillStyle = "white";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    const fontSize = Math.min(cellWidth, cellHeight) / 10;
+    ctx.font = `bold ${fontSize}px sans-serif`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    for (const [index, img] of images.entries()) {
+      const col = index % cols;
+      const row = Math.floor(index / cols);
+      const cellX = col * cellWidth;
+      const cellY = row * cellHeight;
+      const dx = cellX + (cellWidth - img.naturalWidth) / 2;
+      const dy = cellY + (cellHeight - img.naturalHeight) / 2;
+      ctx.drawImage(img, dx, dy);
+      const cx = cellX + cellWidth / 2;
+      const cy = cellY + cellHeight / 2;
+      const { r, g, b } = colors[index].rgb();
+      ctx.globalCompositeOperation = "difference";
+      ctx.fillStyle = d3color.rgb(255 - r, 255 - g, 255 - b).formatHex();
+      ctx.fillText(names[index], cx, cy);
+      ctx.globalCompositeOperation = "source-over";
+    }
+    return await canvas.convertToBlob({ type: "image/png" });
+  } finally {
+    for (const url of urls) {
+      URL.revokeObjectURL(url);
+    }
+  }
 }
 
 export async function genSeparation(
@@ -160,7 +317,11 @@ export async function genSeparation(
   pool: readonly ColorSpaceObject[],
   increments: number,
 ): Promise<readonly Blob[]> {
-  const mapping = new Map<string, number[]>();
+  if (isRaster(blob.type)) {
+    const { separations } = await rasterPipeline(blob, pool, increments);
+    return separations;
+  }
+  const mapping = new Map<RgbU32, number[]>();
   for await (const [key, , opac] of bulkColorSeparation(
     extractColors(blob),
     pool,
@@ -168,16 +329,5 @@ export async function genSeparation(
   )) {
     mapping.set(key, opac);
   }
-
-  return await Promise.all(
-    pool.map((_, ind) => {
-      const updater = (orig: ColorSpaceObject): ColorSpaceObject => {
-        const opacity = mapping.get(orig.formatHex())![ind];
-        const updated = d3color.gray((1 - opacity) * 100);
-        return updated.copy({ opacity: orig.opacity });
-      };
-
-      return updateColors(blob, updater);
-    }),
-  );
+  return await updateColors(blob, separationUpdaters(mapping, pool.length));
 }

--- a/utils/winterface.ts
+++ b/utils/winterface.ts
@@ -1,6 +1,8 @@
+import type { RgbU32 } from "./color";
+
 export interface Message {
-  readonly colors: Set<string>;
-  readonly pool: Uint8ClampedArray;
+  readonly colors: Set<RgbU32>;
+  readonly pool: Uint32Array;
   readonly increments: number;
 }
 
@@ -11,8 +13,23 @@ interface Err {
 
 interface Success {
   readonly typ: "success";
-  readonly prevs: Uint8ClampedArray;
+  readonly prevs: Uint32Array;
   readonly opacs: Float64Array;
 }
 
 export type Result = Err | Success;
+
+export interface RasterMessage {
+  readonly blob: Blob;
+  readonly pool: Uint32Array;
+  readonly increments: number;
+  readonly outputType: string;
+}
+
+interface RasterSuccess {
+  readonly typ: "success";
+  readonly preview: Blob;
+  readonly separations: readonly Blob[];
+}
+
+export type RasterResult = Err | RasterSuccess;

--- a/utils/worker.ts
+++ b/utils/worker.ts
@@ -1,4 +1,5 @@
 import * as d3color from "d3-color";
+import { packRgb, unpackRgb } from "./color";
 import { colorSeparation } from "./sep";
 import type { Message, Result } from "./winterface";
 
@@ -7,21 +8,23 @@ addEventListener("message", (event: MessageEvent<Message>) => {
     const { colors, pool, increments } = event.data;
 
     const colorPool = [];
-    for (let i = 0; i < pool.length; i += 3) {
-      const [r, g, b] = pool.slice(i, i + 3);
+    for (let i = 0; i < pool.length; i++) {
+      const { r, g, b } = unpackRgb(pool[i]);
       colorPool.push(d3color.rgb(r, g, b));
     }
 
-    const prevs = new Uint8ClampedArray(colors.size * 3);
+    const prevs = new Uint32Array(colors.size);
     const opacs = new Float64Array(colors.size * colorPool.length);
     let i = 0;
     for (const key of colors) {
-      const target = d3color.color(key)!;
-      const { color, opacities } = colorSeparation(target, colorPool, {
-        increments,
-      });
-      const { r, g, b } = color.rgb();
-      prevs.set([r, g, b], i * 3);
+      const { r, g, b } = unpackRgb(key);
+      const { color, opacities } = colorSeparation(
+        d3color.rgb(r, g, b),
+        colorPool,
+        { increments },
+      );
+      const { r: pr, g: pg, b: pb } = color.rgb();
+      prevs[i] = packRgb(pr, pg, pb);
       opacs.set(opacities, i * colorPool.length);
       i++;
     }


### PR DESCRIPTION

Adds a "Toggle Channels" button that displays each color separation
rendered in black, laid out in a square-ish grid with the color name
labeled inside each cell. The label glyphs use a difference blend so
they show in the channel color on light regions and the complement on
dark regions, always remaining readable.

Pipeline changes that came along for the ride:
- Raster preview and per-channel separations are produced in a single
  pixel pass via a dedicated worker, off the main thread.
- The worker uses a packed-uint32 RGB lookup table built from the
  unique source colors, eliminating per-pixel d3color/hex allocations.
- Internal color representation is RgbU32 (type alias for number)
  across the worker boundary instead of hex strings and byte arrays.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
