### PR TITLE
feat: add right-click remap on active palette colors

### DIFF
--- a/components/app.tsx
+++ b/components/app.tsx
@@ -49,29 +49,43 @@ export default function App(): ReactElement {
   const [parsed, setParsed] = useState<Parsed | undefined | null>();
   const [colors, modifyColors] = useReducer(
     (
-      existingColors: Map<string, [string, boolean]>,
+      existingColors: Map<string, [string, boolean, string | undefined]>,
       action: Action,
-    ): Map<string, [string, boolean]> => {
+    ): Map<string, [string, boolean, string | undefined]> => {
       if (action.action === "set") {
         return new Map(
-          action.colors.map(([color, name]) => [color, [name, false]]),
+          action.colors.map(([color, name]) => [
+            color,
+            [name, false, undefined],
+          ]),
         );
       } else if (action.action === "add") {
         const copy = new Map(existingColors);
-        copy.set(action.color, [action.name, false]);
+        copy.set(action.color, [action.name, false, undefined]);
         return copy;
       } else if (action.action === "toggle") {
         const copy = new Map(existingColors);
         const [name, state] = copy.get(action.color)!;
-        copy.set(action.color, [name, !state]);
+        // toggling off clears the remap
+        copy.set(action.color, [name, !state, undefined]);
+        return copy;
+      } else if (action.action === "remap") {
+        const copy = new Map(existingColors);
+        const [name, state] = copy.get(action.color)!;
+        // selecting the original color clears the remap
+        const remap = action.remap === action.color ? undefined : action.remap;
+        copy.set(action.color, [name, state, remap]);
         return copy;
       } else {
         return new Map(
-          [...existingColors].map(([color, [name]]) => [color, [name, false]]),
+          [...existingColors].map(([color, [name]]) => [
+            color,
+            [name, false, undefined],
+          ]),
         );
       }
     },
-    new Map<string, [string, boolean]>(),
+    new Map<string, [string, boolean, string | undefined]>(),
   );
 
   const [preview, setPreview] = useState<string | undefined>();
@@ -85,10 +99,12 @@ export default function App(): ReactElement {
       return;
     }
     const pool = [];
+    const renderPool = [];
     const names = [];
-    for (const [color, [name, active]] of colors) {
+    for (const [color, [name, active, remap]] of colors) {
       if (active) {
         pool.push(d3color.color(color)!);
+        renderPool.push(d3color.color(remap ?? color)!);
         names.push(name);
       }
     }
@@ -103,8 +119,8 @@ export default function App(): ReactElement {
         setRendering(true);
         const blob = await url2blob(parsed.preview);
         const { preview: previewBlob, separations } =
-          await genPreviewAndSeparation(blob, pool, increments);
-        const gridBlob = await genGrid(separations, names, pool);
+          await genPreviewAndSeparation(blob, pool, renderPool, increments);
+        const gridBlob = await genGrid(separations, names, renderPool);
         const [previewUrl, gridUrl] = await Promise.all([
           blob2url(previewBlob),
           blob2url(gridBlob),

--- a/components/color-button.tsx
+++ b/components/color-button.tsx
@@ -1,3 +1,4 @@
+import { Menu } from "@ark-ui/react/menu";
 import { Tooltip } from "@ark-ui/react/tooltip";
 import { type ReactElement, useCallback } from "react";
 
@@ -5,40 +6,87 @@ export default function ColorButton({
   color,
   name,
   active,
+  remap,
+  palette,
   toggleColor,
+  remapColor,
   disabled = false,
 }: {
   color: string;
   name: string;
   active: boolean;
+  remap: string | undefined;
+  palette: readonly (readonly [string, string])[];
   toggleColor: (named: string) => void;
+  remapColor: (color: string, remap: string) => void;
   disabled?: boolean;
 }): ReactElement {
   const toggle = useCallback(() => {
     toggleColor(color);
   }, [color, toggleColor]);
-  const col = disabled ? "#cbd5e1" : color;
+  const onSelect = useCallback(
+    (details: { value: string }) => {
+      remapColor(color, details.value);
+    },
+    [color, remapColor],
+  );
   const sty = disabled ? "" : "hover:scale-110";
+  const ringColor = disabled ? "#cbd5e1" : color;
+  const fillColor = active && remap ? remap : "transparent";
+  const buttonClass = `rounded-full transition-all m-1 focus:outline w-8 h-8 ${sty}`;
+  const buttonStyle = {
+    borderWidth: active ? "0.2rem" : "1rem",
+    borderColor: ringColor,
+    outlineColor: ringColor,
+    backgroundColor: fillColor,
+  };
+
+  if (!active || disabled) {
+    return (
+      <Tooltip.Root>
+        <Tooltip.Trigger asChild>
+          <button
+            className={buttonClass}
+            style={buttonStyle}
+            onClick={toggle}
+            disabled={disabled}
+            type="button"
+          />
+        </Tooltip.Trigger>
+        <Tooltip.Positioner>
+          <Tooltip.Content className="bg-slate-800 dark:bg-slate-700 text-white text-sm px-2 py-1 rounded shadow">
+            {name}
+          </Tooltip.Content>
+        </Tooltip.Positioner>
+      </Tooltip.Root>
+    );
+  }
   return (
-    <Tooltip.Root>
-      <Tooltip.Trigger asChild>
-        <button
-          className={`rounded-full bg-transparent transition-all m-1 focus:outline w-8 h-8 ${sty}`}
-          style={{
-            borderWidth: active ? "0.2rem" : "1rem",
-            borderColor: col,
-            outlineColor: col,
-          }}
-          onClick={toggle}
-          disabled={disabled}
-          type="button"
-        />
-      </Tooltip.Trigger>
-      <Tooltip.Positioner>
-        <Tooltip.Content className="bg-slate-800 dark:bg-slate-700 text-white text-sm px-2 py-1 rounded shadow">
-          {name}
-        </Tooltip.Content>
-      </Tooltip.Positioner>
-    </Tooltip.Root>
+    <Menu.Root onSelect={onSelect}>
+      <Menu.ContextTrigger
+        className={buttonClass}
+        style={buttonStyle}
+        onClick={toggle}
+        type="button"
+        title={name}
+      />
+      <Menu.Positioner>
+        <Menu.Content className="bg-white dark:bg-slate-800 border border-slate-300 dark:border-slate-600 rounded shadow-lg p-1 z-50 focus:outline-none">
+          {palette.map(([paletteColor, paletteName]) => (
+            <Menu.Item
+              key={paletteColor}
+              value={paletteColor}
+              className="flex items-center gap-2 px-2 py-1 rounded cursor-pointer data-[highlighted]:bg-slate-100 dark:data-[highlighted]:bg-slate-700"
+            >
+              <span
+                className="inline-block w-4 h-4 rounded-full border border-slate-300 dark:border-slate-600"
+                style={{ backgroundColor: paletteColor }}
+              />
+              <span className="text-sm">{paletteName}</span>
+            </Menu.Item>
+          ))}
+        </Menu.Content>
+      </Menu.Positioner>
+    </Menu.Root>
   );
 }

--- a/components/color-picker.tsx
+++ b/components/color-picker.tsx
@@ -4,19 +4,27 @@ import ColorButton from "./color-button";
 export default function ColorPicker({
   colors,
   toggleColor,
+  remapColor,
   disabled,
 }: {
-  colors: Map<string, [string, boolean]>;
+  colors: Map<string, [string, boolean, string | undefined]>;
   toggleColor: (color: string) => void;
+  remapColor: (color: string, remap: string) => void;
   disabled: boolean;
 }): ReactElement {
   // TODO for colors we know, we may want to use their cmyk variant since it
   // doesn't use the simple 1-1
-  const buttons = [...colors].map(([color, [name, active]]) => (
+  const palette: readonly (readonly [string, string])[] = [...colors].map(
+    ([hex, [name]]) => [hex, name],
+  );
+  const buttons = [...colors].map(([color, [name, active, remap]]) => (
     <ColorButton
       color={color}
       name={name}
       toggleColor={toggleColor}
+      remapColor={remapColor}
+      remap={remap}
+      palette={palette}
       active={active}
       disabled={disabled}
       key={color}

--- a/components/editor.tsx
+++ b/components/editor.tsx
@@ -9,6 +9,7 @@ export type Action =
   | { action: "set"; colors: readonly (readonly [string, string])[] }
   | { action: "add"; color: string; name: string }
   | { action: "toggle"; color: string }
+  | { action: "remap"; color: string; remap: string }
   | { action: "clear" };
 
 function EditorHeader({ children }: PropsWithChildren): ReactElement {
@@ -26,7 +27,7 @@ export default function Editor({
   setShowGrid,
   rendering,
 }: {
-  colors: Map<string, [string, boolean]>;
+  colors: Map<string, [string, boolean, string | undefined]>;
   modifyColors: (action: Action) => void;
   increments: number;
   setIncrements: (inc: number) => void;
@@ -54,6 +55,12 @@ export default function Editor({
   const toggleColor = useCallback(
     (color: string) => {
       modifyColors({ action: "toggle", color });
+    },
+    [modifyColors],
+  );
+  const remapColor = useCallback(
+    (color: string, remap: string) => {
+      modifyColors({ action: "remap", color, remap });
     },
     [modifyColors],
   );
@@ -117,6 +124,7 @@ export default function Editor({
       <ColorPicker
         colors={colors}
         toggleColor={toggleColor}
+        remapColor={remapColor}
         disabled={rendering}
       />
       <EditorHeader>Palette</EditorHeader>

--- a/components/palette-input.tsx
+++ b/components/palette-input.tsx
@@ -31,7 +31,7 @@ export default function PaletteInput({
   setPalette,
   addColor,
 }: {
-  colors: Map<string, [string, boolean]>;
+  colors: Map<string, [string, boolean, string | undefined]>;
   setPalette: (colors: readonly (readonly [string, string])[]) => void;
   addColor: (color: string, name: string) => void;
 }): ReactElement {

--- a/utils/bulksep.ts
+++ b/utils/bulksep.ts
@@ -5,6 +5,7 @@ import type { Result } from "./winterface";
 export async function* bulkColorSeparation(
   colorIter: AsyncIterable<RgbU32>,
   pool: readonly ColorSpaceObject[],
+  renderPool: readonly ColorSpaceObject[],
   increments: number,
 ): AsyncIterableIterator<[RgbU32, RgbU32, number[]]> {
   const colors = new Set<RgbU32>();
@@ -12,12 +13,22 @@ export async function* bulkColorSeparation(
     colors.add(color);
   }
   const transPool = new Uint32Array(pool.length);
+  const transRender = new Uint32Array(renderPool.length);
   for (const [i, color] of pool.entries()) {
     const { r, g, b } = color.rgb();
     transPool[i] = packRgb(r, g, b);
   }
+  for (const [i, color] of renderPool.entries()) {
+    const { r, g, b } = color.rgb();
+    transRender[i] = packRgb(r, g, b);
+  }
 
-  const message = { colors, pool: transPool, increments };
+  const message = {
+    colors,
+    pool: transPool,
+    renderPool: transRender,
+    increments,
+  };
   const worker = new Worker(new URL("./worker.ts", import.meta.url));
   const res = await new Promise<Result>((resolve) => {
     worker.addEventListener("message", (event: MessageEvent<Result>) => {
@@ -25,7 +36,10 @@ export async function* bulkColorSeparation(
       worker.terminate();
     });
     worker.postMessage(message, {
-      transfer: [transPool.buffer as ArrayBuffer],
+      transfer: [
+        transPool.buffer as ArrayBuffer,
+        transRender.buffer as ArrayBuffer,
+      ],
     });
   });
   if (res.typ === "err") {

--- a/utils/raster-worker.ts
+++ b/utils/raster-worker.ts
@@ -1,6 +1,6 @@
 import * as d3color from "d3-color";
 import { packRgb, type RgbU32, unpackRgb } from "./color";
-import { colorSeparation } from "./sep";
+import { colorSeparation, composeColors } from "./sep";
 import type { RasterMessage, RasterResult } from "./winterface";
 
 addEventListener("message", (event: MessageEvent<RasterMessage>) => {
@@ -9,7 +9,7 @@ addEventListener("message", (event: MessageEvent<RasterMessage>) => {
 
 async function run(message: RasterMessage): Promise<void> {
   try {
-    const { blob, pool, increments, outputType } = message;
+    const { blob, pool, renderPool, increments, outputType } = message;
     const numChannels = pool.length;
     const numOutputs = 1 + numChannels;
 
@@ -28,21 +28,26 @@ async function run(message: RasterMessage): Promise<void> {
     }
 
     const colorPool: d3color.RGBColor[] = [];
+    const renderColors: d3color.RGBColor[] = [];
     for (let i = 0; i < pool.length; i++) {
       const { r, g, b } = unpackRgb(pool[i]);
       colorPool.push(d3color.rgb(r, g, b));
+      const { r: rr, g: rg, b: rb } = unpackRgb(renderPool[i]);
+      renderColors.push(d3color.rgb(rr, rg, rb));
     }
 
     const triples = numOutputs * 3;
     const lookup = new Map<RgbU32, Uint8Array>();
     for (const key of unique) {
       const { r, g, b } = unpackRgb(key);
-      const { color, opacities } = colorSeparation(
-        d3color.rgb(r, g, b),
-        colorPool,
-        { increments },
-      );
-      const { r: pr, g: pg, b: pb } = color.rgb();
+      const { opacities } = colorSeparation(d3color.rgb(r, g, b), colorPool, {
+        increments,
+      });
+      const {
+        r: pr,
+        g: pg,
+        b: pb,
+      } = composeColors(opacities, renderColors).rgb();
       const bytes = new Uint8Array(triples);
       bytes[0] = pr;
       bytes[1] = pg;

--- a/utils/sep.ts
+++ b/utils/sep.ts
@@ -111,8 +111,27 @@ export function colorSeparation(
   );
   const cond = opacities.reduce((s, v, i) => s + weights[i] * v, 0);
   const error = (result - cond) / (3 * 255);
-  const total = opacities.reduce((t, o) => t + o, 0);
 
+  return {
+    error,
+    opacities,
+    color: composeColors(opacities, rgbPool),
+  };
+}
+
+/**
+ * Subtractive linear composite of pool colors at given opacities over white.
+ *
+ * Splits out the compositing step so callers can re-render the preview against
+ * a different pool of colors (e.g. user-chosen remaps) while keeping the
+ * opacities optimized for the original separation pool.
+ */
+export function composeColors(
+  opacities: readonly number[],
+  pool: readonly ColorSpaceObject[],
+): ColorSpaceObject {
+  const rgbPool = pool.map((color) => color.rgb());
+  const total = opacities.reduce((t, o) => t + o, 0);
   const init = 255 * (1 - total);
   const closest = d3color.rgb(init, init, init);
   for (const [i, color] of rgbPool.entries()) {
@@ -121,9 +140,5 @@ export function colorSeparation(
       closest[prop] += color[prop] * opacity;
     }
   }
-  return {
-    error,
-    opacities,
-    color: closest.clamp(),
-  };
+  return closest.clamp();
 }

--- a/utils/separate.ts
+++ b/utils/separate.ts
@@ -14,16 +14,23 @@ function isRaster(type: string): boolean {
 async function rasterPipeline(
   blob: Blob,
   pool: readonly ColorSpaceObject[],
+  renderPool: readonly ColorSpaceObject[],
   increments: number,
 ): Promise<{ preview: Blob; separations: readonly Blob[] }> {
   const transPool = new Uint32Array(pool.length);
+  const transRender = new Uint32Array(renderPool.length);
   for (const [i, color] of pool.entries()) {
     const { r, g, b } = color.rgb();
     transPool[i] = packRgb(r, g, b);
   }
+  for (const [i, color] of renderPool.entries()) {
+    const { r, g, b } = color.rgb();
+    transRender[i] = packRgb(r, g, b);
+  }
   const message: RasterMessage = {
     blob,
     pool: transPool,
+    renderPool: transRender,
     increments,
     outputType: blob.type,
   };
@@ -34,7 +41,10 @@ async function rasterPipeline(
       worker.terminate();
     });
     worker.postMessage(message, {
-      transfer: [transPool.buffer as ArrayBuffer],
+      transfer: [
+        transPool.buffer as ArrayBuffer,
+        transRender.buffer as ArrayBuffer,
+      ],
     });
   });
   if (result.typ === "err") {
@@ -214,16 +224,23 @@ function separationUpdaters(
 export async function genPreview(
   blob: Blob,
   pool: readonly ColorSpaceObject[],
+  renderPool: readonly ColorSpaceObject[],
   increments: number,
 ): Promise<Blob> {
   if (isRaster(blob.type)) {
-    const { preview } = await rasterPipeline(blob, pool, increments);
+    const { preview } = await rasterPipeline(
+      blob,
+      pool,
+      renderPool,
+      increments,
+    );
     return preview;
   }
   const update = new Map<RgbU32, RgbU32>();
   for await (const [key, color] of bulkColorSeparation(
     extractColors(blob),
     pool,
+    renderPool,
     increments,
   )) {
     update.set(key, color);
@@ -235,16 +252,18 @@ export async function genPreview(
 export async function genPreviewAndSeparation(
   blob: Blob,
   pool: readonly ColorSpaceObject[],
+  renderPool: readonly ColorSpaceObject[],
   increments: number,
 ): Promise<{ preview: Blob; separations: readonly Blob[] }> {
   if (isRaster(blob.type)) {
-    return await rasterPipeline(blob, pool, increments);
+    return await rasterPipeline(blob, pool, renderPool, increments);
   }
   const update = new Map<RgbU32, RgbU32>();
   const mapping = new Map<RgbU32, number[]>();
   for await (const [key, color, opac] of bulkColorSeparation(
     extractColors(blob),
     pool,
+    renderPool,
     increments,
   )) {
     update.set(key, color);
@@ -318,12 +337,13 @@ export async function genSeparation(
   increments: number,
 ): Promise<readonly Blob[]> {
   if (isRaster(blob.type)) {
-    const { separations } = await rasterPipeline(blob, pool, increments);
+    const { separations } = await rasterPipeline(blob, pool, pool, increments);
     return separations;
   }
   const mapping = new Map<RgbU32, number[]>();
   for await (const [key, , opac] of bulkColorSeparation(
     extractColors(blob),
+    pool,
     pool,
     increments,
   )) {

--- a/utils/winterface.ts
+++ b/utils/winterface.ts
@@ -3,6 +3,7 @@ import type { RgbU32 } from "./color";
 export interface Message {
   readonly colors: Set<RgbU32>;
   readonly pool: Uint32Array;
+  readonly renderPool: Uint32Array;
   readonly increments: number;
 }
 
@@ -22,6 +23,7 @@ export type Result = Err | Success;
 export interface RasterMessage {
   readonly blob: Blob;
   readonly pool: Uint32Array;
+  readonly renderPool: Uint32Array;
   readonly increments: number;
   readonly outputType: string;
 }

--- a/utils/worker.ts
+++ b/utils/worker.ts
@@ -1,16 +1,19 @@
 import * as d3color from "d3-color";
 import { packRgb, unpackRgb } from "./color";
-import { colorSeparation } from "./sep";
+import { colorSeparation, composeColors } from "./sep";
 import type { Message, Result } from "./winterface";
 
 addEventListener("message", (event: MessageEvent<Message>) => {
   try {
-    const { colors, pool, increments } = event.data;
+    const { colors, pool, renderPool, increments } = event.data;
 
     const colorPool = [];
+    const renderColors = [];
     for (let i = 0; i < pool.length; i++) {
       const { r, g, b } = unpackRgb(pool[i]);
       colorPool.push(d3color.rgb(r, g, b));
+      const { r: rr, g: rg, b: rb } = unpackRgb(renderPool[i]);
+      renderColors.push(d3color.rgb(rr, rg, rb));
     }
 
     const prevs = new Uint32Array(colors.size);
@@ -18,12 +21,14 @@ addEventListener("message", (event: MessageEvent<Message>) => {
     let i = 0;
     for (const key of colors) {
       const { r, g, b } = unpackRgb(key);
-      const { color, opacities } = colorSeparation(
-        d3color.rgb(r, g, b),
-        colorPool,
-        { increments },
-      );
-      const { r: pr, g: pg, b: pb } = color.rgb();
+      const { opacities } = colorSeparation(d3color.rgb(r, g, b), colorPool, {
+        increments,
+      });
+      const {
+        r: pr,
+        g: pg,
+        b: pb,
+      } = composeColors(opacities, renderColors).rgb();
       prevs[i] = packRgb(pr, pg, pb);
       opacs.set(opacities, i * colorPool.length);
       i++;


### PR DESCRIPTION

Right-clicking an active palette swatch opens a menu of palette colors;
picking one remaps that channel for rendering only. The separation math
still optimizes against the original channel color, but the preview
composite and channel grid label use the remap color. Selecting the
original color or deactivating the swatch clears the remap.

Pipeline: workers and bulksep now accept a `renderPool` alongside the
optimization `pool`. Opacities come from colorSeparation against `pool`,
and the preview composite is rebuilt via a new `composeColors` helper
against `renderPool`. Per-channel separation files (download) keep using
`pool` for both since their grayscale output is render-color-independent.

UI: active+remap swatches show a thin ring in the original color with
the remap color filled inside; the dropdown lists each palette color by
name with its swatch.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
