### PR TITLE
feat: keep color swatches interactive while rendering

### DIFF
--- a/components/color-button.tsx
+++ b/components/color-button.tsx
@@ -10,7 +10,7 @@ export default function ColorButton({
   palette,
   toggleColor,
   remapColor,
-  disabled = false,
+  muted = false,
 }: {
   color: string;
   name: string;
@@ -19,7 +19,7 @@ export default function ColorButton({
   palette: readonly (readonly [string, string])[];
   toggleColor: (named: string) => void;
   remapColor: (color: string, remap: string) => void;
-  disabled?: boolean;
+  muted?: boolean;
 }): ReactElement {
   const toggle = useCallback(() => {
     toggleColor(color);
@@ -30,18 +30,16 @@ export default function ColorButton({
     },
     [color, remapColor],
   );
-  const sty = disabled ? "" : "hover:scale-110";
-  const ringColor = disabled ? "#cbd5e1" : color;
   const fillColor = active && remap ? remap : "transparent";
-  const buttonClass = `rounded-full transition-all m-1 focus:outline w-8 h-8 ${sty}`;
+  const buttonClass = `rounded-full transition-all m-1 focus:outline w-8 h-8 hover:scale-110 ${muted ? "opacity-50" : ""}`;
   const buttonStyle = {
     borderWidth: active ? "0.2rem" : "1rem",
-    borderColor: ringColor,
-    outlineColor: ringColor,
+    borderColor: color,
+    outlineColor: color,
     backgroundColor: fillColor,
   };
 
-  if (!active || disabled) {
+  if (!active) {
     return (
       <Tooltip.Root>
         <Tooltip.Trigger asChild>
@@ -49,7 +47,6 @@ export default function ColorButton({
             className={buttonClass}
             style={buttonStyle}
             onClick={toggle}
-            disabled={disabled}
             type="button"
           />
         </Tooltip.Trigger>

--- a/components/color-picker.tsx
+++ b/components/color-picker.tsx
@@ -5,12 +5,12 @@ export default function ColorPicker({
   colors,
   toggleColor,
   remapColor,
-  disabled,
+  muted,
 }: {
   colors: Map<string, [string, boolean, string | undefined]>;
   toggleColor: (color: string) => void;
   remapColor: (color: string, remap: string) => void;
-  disabled: boolean;
+  muted: boolean;
 }): ReactElement {
   // TODO for colors we know, we may want to use their cmyk variant since it
   // doesn't use the simple 1-1
@@ -26,7 +26,7 @@ export default function ColorPicker({
       remap={remap}
       palette={palette}
       active={active}
-      disabled={disabled}
+      muted={muted}
       key={color}
     />
   ));

--- a/components/editor.tsx
+++ b/components/editor.tsx
@@ -125,7 +125,7 @@ export default function Editor({
         colors={colors}
         toggleColor={toggleColor}
         remapColor={remapColor}
-        disabled={rendering}
+        muted={rendering}
       />
       <EditorHeader>Palette</EditorHeader>
       <p className="text-slate-600 dark:text-slate-400">


### PR DESCRIPTION

Previously the palette greyed out and disabled clicks during render.
Now swatches mute to 50% opacity but stay clickable; toggles and
remaps fire immediately, the rendering effect's cancel guard drops
the superseded in-flight result.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
