### PR TITLE
feat: add sparsity penalty via iterative reweighted L1

### DIFF
--- a/components/app.tsx
+++ b/components/app.tsx
@@ -91,6 +91,7 @@ export default function App(): ReactElement {
   const [preview, setPreview] = useState<string | undefined>();
   const [grid, setGrid] = useState<string | undefined>();
   const [increments, setIncrements] = useState(0);
+  const [lambda, setLambda] = useState(0);
 
   useEffect(() => {
     if (!parsed) {
@@ -119,7 +120,13 @@ export default function App(): ReactElement {
         setRendering(true);
         const blob = await url2blob(parsed.preview);
         const { preview: previewBlob, separations } =
-          await genPreviewAndSeparation(blob, pool, renderPool, increments);
+          await genPreviewAndSeparation(
+            blob,
+            pool,
+            renderPool,
+            increments,
+            lambda,
+          );
         const gridBlob = await genGrid(separations, names, renderPool);
         const [previewUrl, gridUrl] = await Promise.all([
           blob2url(previewBlob),
@@ -148,7 +155,7 @@ export default function App(): ReactElement {
     return () => {
       cancelled = true;
     };
-  }, [colors, increments, parsed]);
+  }, [colors, increments, parsed, lambda]);
 
   const download = useCallback(() => {
     if (parsed) {
@@ -168,7 +175,12 @@ export default function App(): ReactElement {
             }
           }
 
-          const blobs = await genSeparation(parsed.raw, pool, increments);
+          const blobs = await genSeparation(
+            parsed.raw,
+            pool,
+            increments,
+            lambda,
+          );
           for (const [ind, name] of names.entries()) {
             const blob = blobs[ind];
             const ext = extension(blob.type);
@@ -185,7 +197,7 @@ export default function App(): ReactElement {
         }
       })();
     }
-  }, [parsed, colors, increments]);
+  }, [parsed, colors, increments, lambda]);
 
   const onUpload = useCallback((file: File) => {
     void (async () => {
@@ -216,6 +228,8 @@ export default function App(): ReactElement {
         modifyColors={modifyColors}
         increments={increments}
         setIncrements={setIncrements}
+        lambda={lambda}
+        setLambda={setLambda}
         download={download}
         isDownloading={isDownloading}
         setShowRaw={setShowRaw}

--- a/components/editor.tsx
+++ b/components/editor.tsx
@@ -21,6 +21,8 @@ export default function Editor({
   modifyColors,
   increments,
   setIncrements,
+  lambda,
+  setLambda,
   download,
   isDownloading,
   setShowRaw,
@@ -31,6 +33,8 @@ export default function Editor({
   modifyColors: (action: Action) => void;
   increments: number;
   setIncrements: (inc: number) => void;
+  lambda: number;
+  setLambda: (lambda: number) => void;
   download: () => void;
   isDownloading: boolean;
   setShowRaw: (val: boolean) => void;
@@ -148,7 +152,6 @@ export default function Editor({
           min={0}
           max={7}
           step={1}
-          disabled={rendering}
         >
           <Slider.Control className="relative flex items-center h-5">
             <Slider.Track className="relative h-2 w-full rounded bg-slate-300 dark:bg-slate-600">
@@ -156,7 +159,30 @@ export default function Editor({
             </Slider.Track>
             <Slider.Thumb
               index={0}
-              className="absolute w-5 h-5 bg-white dark:bg-slate-200 border-2 border-slate-400 dark:border-slate-400 rounded-full shadow cursor-pointer -translate-x-1/2"
+              className="absolute w-5 h-5 bg-white dark:bg-slate-200 border-2 border-slate-400 dark:border-slate-400 rounded-full shadow cursor-pointer"
+            />
+          </Slider.Control>
+        </Slider.Root>
+      </div>
+      <EditorHeader>Sparsity</EditorHeader>
+      <p className="text-slate-600 dark:text-slate-400">
+        Bias the separation toward fewer pool colors per output color.
+      </p>
+      <div className="px-4">
+        <Slider.Root
+          value={[lambda]}
+          onValueChange={(details) => setLambda(details.value[0])}
+          min={0}
+          max={1}
+          step={0.05}
+        >
+          <Slider.Control className="relative flex items-center h-5">
+            <Slider.Track className="relative h-2 w-full rounded bg-slate-300 dark:bg-slate-600">
+              <Slider.Range className="absolute h-full rounded bg-slate-400 dark:bg-slate-500" />
+            </Slider.Track>
+            <Slider.Thumb
+              index={0}
+              className="absolute w-5 h-5 bg-white dark:bg-slate-200 border-2 border-slate-400 dark:border-slate-400 rounded-full shadow cursor-pointer"
             />
           </Slider.Control>
         </Slider.Root>

--- a/utils/bulksep.ts
+++ b/utils/bulksep.ts
@@ -7,6 +7,7 @@ export async function* bulkColorSeparation(
   pool: readonly ColorSpaceObject[],
   renderPool: readonly ColorSpaceObject[],
   increments: number,
+  lambda: number,
 ): AsyncIterableIterator<[RgbU32, RgbU32, number[]]> {
   const colors = new Set<RgbU32>();
   for await (const color of colorIter) {
@@ -28,6 +29,7 @@ export async function* bulkColorSeparation(
     pool: transPool,
     renderPool: transRender,
     increments,
+    lambda,
   };
   const worker = new Worker(new URL("./worker.ts", import.meta.url));
   const res = await new Promise<Result>((resolve) => {

--- a/utils/raster-worker.ts
+++ b/utils/raster-worker.ts
@@ -9,7 +9,7 @@ addEventListener("message", (event: MessageEvent<RasterMessage>) => {
 
 async function run(message: RasterMessage): Promise<void> {
   try {
-    const { blob, pool, renderPool, increments, outputType } = message;
+    const { blob, pool, renderPool, increments, lambda, outputType } = message;
     const numChannels = pool.length;
     const numOutputs = 1 + numChannels;
 
@@ -42,6 +42,7 @@ async function run(message: RasterMessage): Promise<void> {
       const { r, g, b } = unpackRgb(key);
       const { opacities } = colorSeparation(d3color.rgb(r, g, b), colorPool, {
         increments,
+        lambda,
       });
       const {
         r: pr,

--- a/utils/sep.ts
+++ b/utils/sep.ts
@@ -28,50 +28,51 @@ export interface Result {
   opacities: number[];
 }
 
+const L1_ITERATIONS = 4;
+const L1_EPSILON = 0.01;
+const LAMBDA_SCALE = 255;
+
 /**
  * Perform approximate subtractive color separation
  *
- * All colors should be in standard (non-alpha) hex, e.g. "#rrggbb".
- *
  * @param target - the target color
  * @param pool - an array of the available colors
- * @param quadratic - true if using quadratic optimization
  * @param increments - the number of color increments to use; opacities will
  *   always be multiples of 1 / increments; if 0 then use continuous increments
+ * @param lambda - sparsity penalty in [0, 1], scaled internally; > 0 enables
+ *   iterative reweighted L1 to bias toward fewer pool colors per output
  */
 export function colorSeparation(
   target: ColorSpaceObject,
   pool: readonly ColorSpaceObject[],
   {
     increments = 0,
+    lambda = 0,
   }: {
     increments?: number;
+    lambda?: number;
   } = {},
 ): Result {
   const rgbTarget = target.rgb();
   const rgbPool = pool.map((color) => color.rgb());
 
   const mult = Math.max(increments, 1);
-  const weighting = 1e-7;
-  const weights = rgbPool.map(({ r, g, b }) => weighting * (r + g + b));
+  const tieBreak = 1e-7;
+  const tieWeights = rgbPool.map(({ r, g, b }) => tieBreak * (r + g + b));
 
   const constraints: Record<string, Constraint> = {};
   const variables: Record<string, Variable> = {};
   const ints: Record<string, 1> = {};
 
-  for (const [j, weight] of weights.entries()) {
-    // maximum weight of 1
+  for (const [j, weight] of tieWeights.entries()) {
     const mx = `mx ${j}`;
     constraints[mx] = { max: mult };
-
-    // tie break towards lighter colors
     variables[`mix ${j}`] = { error: weight, [mx]: 1 };
   }
 
   for (const prop of ["r", "g", "b"] as const) {
     const channel = 255 - rgbTarget[prop];
 
-    // slack variable for absolute value loss
     const up = `up ${prop}`;
     constraints[up] = { max: channel };
 
@@ -90,27 +91,56 @@ export function colorSeparation(
   }
 
   if (increments > 0) {
-    for (const [j] of weights.entries()) {
+    for (const [j] of tieWeights.entries()) {
       ints[`mix ${j}`] = 1;
     }
   }
 
-  const { result, feasible, bounded, ...vals } = solver.Solve({
-    optimize: "error",
-    opType: "min",
-    constraints,
-    variables,
-    ints,
-  });
-  /* istanbul ignore if */
-  if (!feasible || !bounded) {
-    throw new Error("couldn't find bounded feasible solution");
+  const effectiveLambda = lambda * LAMBDA_SCALE;
+
+  const solveOnce = (): Record<string, number> => {
+    const {
+      result: _result,
+      feasible,
+      bounded,
+      ...vals
+    } = solver.Solve({
+      optimize: "error",
+      opType: "min",
+      constraints,
+      variables,
+      ints,
+    });
+    /* istanbul ignore if */
+    if (!feasible || !bounded) {
+      throw new Error("couldn't find bounded feasible solution");
+    }
+    return vals;
+  };
+
+  let vals: Record<string, number>;
+  if (effectiveLambda > 0) {
+    vals = solveOnce();
+    for (let iter = 0; iter < L1_ITERATIONS; iter++) {
+      for (const [j, tie] of tieWeights.entries()) {
+        const opacity = (vals[`mix ${j}`] ?? 0) / mult;
+        variables[`mix ${j}`].error =
+          tie + effectiveLambda / (opacity + L1_EPSILON);
+      }
+      vals = solveOnce();
+    }
+  } else {
+    vals = solveOnce();
   }
+
   const opacities = rgbPool.map((_, i) =>
     Math.min((vals[`mix ${i}`] ?? 0) / mult, 1),
   );
-  const cond = opacities.reduce((s, v, i) => s + weights[i] * v, 0);
-  const error = (result - cond) / (3 * 255);
+  let slackSum = 0;
+  for (const prop of ["r", "g", "b"] as const) {
+    slackSum += vals[`slack ${prop}`] ?? 0;
+  }
+  const error = slackSum / (3 * 255);
 
   return {
     error,

--- a/utils/separate.ts
+++ b/utils/separate.ts
@@ -16,6 +16,7 @@ async function rasterPipeline(
   pool: readonly ColorSpaceObject[],
   renderPool: readonly ColorSpaceObject[],
   increments: number,
+  lambda: number,
 ): Promise<{ preview: Blob; separations: readonly Blob[] }> {
   const transPool = new Uint32Array(pool.length);
   const transRender = new Uint32Array(renderPool.length);
@@ -32,6 +33,7 @@ async function rasterPipeline(
     pool: transPool,
     renderPool: transRender,
     increments,
+    lambda,
     outputType: blob.type,
   };
   const worker = new Worker(new URL("./raster-worker.ts", import.meta.url));
@@ -226,6 +228,7 @@ export async function genPreview(
   pool: readonly ColorSpaceObject[],
   renderPool: readonly ColorSpaceObject[],
   increments: number,
+  lambda: number,
 ): Promise<Blob> {
   if (isRaster(blob.type)) {
     const { preview } = await rasterPipeline(
@@ -233,6 +236,7 @@ export async function genPreview(
       pool,
       renderPool,
       increments,
+      lambda,
     );
     return preview;
   }
@@ -242,6 +246,7 @@ export async function genPreview(
     pool,
     renderPool,
     increments,
+    lambda,
   )) {
     update.set(key, color);
   }
@@ -254,9 +259,10 @@ export async function genPreviewAndSeparation(
   pool: readonly ColorSpaceObject[],
   renderPool: readonly ColorSpaceObject[],
   increments: number,
+  lambda: number,
 ): Promise<{ preview: Blob; separations: readonly Blob[] }> {
   if (isRaster(blob.type)) {
-    return await rasterPipeline(blob, pool, renderPool, increments);
+    return await rasterPipeline(blob, pool, renderPool, increments, lambda);
   }
   const update = new Map<RgbU32, RgbU32>();
   const mapping = new Map<RgbU32, number[]>();
@@ -265,6 +271,7 @@ export async function genPreviewAndSeparation(
     pool,
     renderPool,
     increments,
+    lambda,
   )) {
     update.set(key, color);
     mapping.set(key, opac);
@@ -335,9 +342,16 @@ export async function genSeparation(
   blob: Blob,
   pool: readonly ColorSpaceObject[],
   increments: number,
+  lambda: number,
 ): Promise<readonly Blob[]> {
   if (isRaster(blob.type)) {
-    const { separations } = await rasterPipeline(blob, pool, pool, increments);
+    const { separations } = await rasterPipeline(
+      blob,
+      pool,
+      pool,
+      increments,
+      lambda,
+    );
     return separations;
   }
   const mapping = new Map<RgbU32, number[]>();
@@ -346,6 +360,7 @@ export async function genSeparation(
     pool,
     pool,
     increments,
+    lambda,
   )) {
     mapping.set(key, opac);
   }

--- a/utils/winterface.ts
+++ b/utils/winterface.ts
@@ -5,6 +5,7 @@ export interface Message {
   readonly pool: Uint32Array;
   readonly renderPool: Uint32Array;
   readonly increments: number;
+  readonly lambda: number;
 }
 
 interface Err {
@@ -25,6 +26,7 @@ export interface RasterMessage {
   readonly pool: Uint32Array;
   readonly renderPool: Uint32Array;
   readonly increments: number;
+  readonly lambda: number;
   readonly outputType: string;
 }
 

--- a/utils/worker.ts
+++ b/utils/worker.ts
@@ -5,7 +5,7 @@ import type { Message, Result } from "./winterface";
 
 addEventListener("message", (event: MessageEvent<Message>) => {
   try {
-    const { colors, pool, renderPool, increments } = event.data;
+    const { colors, pool, renderPool, increments, lambda } = event.data;
 
     const colorPool = [];
     const renderColors = [];
@@ -23,6 +23,7 @@ addEventListener("message", (event: MessageEvent<Message>) => {
       const { r, g, b } = unpackRgb(key);
       const { opacities } = colorSeparation(d3color.rgb(r, g, b), colorPool, {
         increments,
+        lambda,
       });
       const {
         r: pr,


### PR DESCRIPTION

Bias the optimizer toward fewer pool colors per output color via a
reweighted L1 penalty on the mix variables. Adds a Sparsity slider
(0-1, normalized by 255 internally) wired through the workers and
separation pipeline. Also fixes a Tailwind v4 / zag double-translate
bug that prevented slider thumbs from reaching the track ends, and
keeps the discretizations slider interactive while rendering.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
